### PR TITLE
Log Function Optimizations

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.Rhistory
 *.o
 *.dll
+.Rproj.user

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,6 +5,47 @@
     .Call('msdeTest_sdeEulerSim', PACKAGE = 'msdeTest', nDataOut, N, reps, r, delta, MAXBAD, initData, params)
 }
 
+plnorm_rand <- function() {
+    .Call('msdeTest_plnorm_rand', PACKAGE = 'msdeTest')
+}
+
+#' Simulate random standard normals using the polar form of the Box-Muller 
+#' transformation.  Box-Muller is much faster than the Inversion method,
+#' and this method is a faster version of that provided that the unif_rand
+#' function is fast (otherwise performance is near BM).  Sample timings below.
+#'
+#'  > n = 5000000
+#'  > message("R standard")
+#'  R standard
+#'  > RNGkind(kind="Mersenne-Twister")
+#'  > RNGkind(normal.kind = "Inversion")
+#'  > system.time(rnorm(n))
+#'     user  system elapsed 
+#'    0.444   0.004   0.450 
+#'  > message("BM + Twister")
+#'  BM + Twister
+#'  > RNGkind(normal.kind = "Box-Muller")
+#'  > system.time(rnorm(n))
+#'     user  system elapsed 
+#'    0.278   0.003   0.282 
+#'  > message("Polar + Twister")
+#'  Polar + Twister
+#'  > system.time(msdeTest:::rplnorm(n))
+#'     user  system elapsed 
+#'    0.270   0.003   0.274 
+#'  > message("Polar + Carry")
+#'  Polar + Carry
+#'  > RNGkind(kind="Marsaglia-Multicarry")
+#'  > system.time(msdeTest:::rplnorm(n))
+#'     user  system elapsed 
+#'    0.234   0.003   0.238 
+#' @param n Number of draws to take.
+#' @return The size of the multinomial distributions
+#' @export
+rplnorm <- function(n) {
+    .Call('msdeTest_rplnorm', PACKAGE = 'msdeTest', n)
+}
+
 .hestDrift <- function(xIn, thetaIn, nReps) {
     .Call('msdeTest_sdeDrift', PACKAGE = 'msdeTest', xIn, thetaIn, nReps)
 }

--- a/inst/cppTemplates/EulerSim.cpp
+++ b/inst/cppTemplates/EulerSim.cpp
@@ -49,13 +49,13 @@ List sdeEulerSim(int nDataOut,
 	mvEuler(mvX[ii]->mean, mvX[ii]->sd, X, delta, sqrtDelta,
 		&params[ii*nParams], &sde[ii]);
 	for(kk = 0; kk < nDims; kk++) {
-	  mvX[ii]->z[kk] = norm_rand();
+	  mvX[ii]->z[kk] = NORM_RAND();
 	}
 	xmvn(tmpX, mvX[ii]->z, mvX[ii]->mean, mvX[ii]->sd, nDims);
 	// validate draw
 	while(!sdeModel::isValidData(tmpX) && bad < MAXBAD) {
 	  for(kk = 0; kk < nDims; kk++) {
-	    mvX[ii]->z[kk] = norm_rand();
+	    mvX[ii]->z[kk] = NORM_RAND();
 	  }
 	  xmvn(tmpX, mvX[ii]->z, mvX[ii]->mean, mvX[ii]->sd, nDims);
 	  bad++;

--- a/inst/cppTemplates/missGibbsUpdate.cpp
+++ b/inst/cppTemplates/missGibbsUpdate.cpp
@@ -27,13 +27,13 @@ void sdeMCMC::missGibbsUpdate(double *jumpSd, int *gibbsAccept, int *paramAccept
 		 &currX[(ii+1)*nDims], B[ii], sqrtB[ii], currTheta, &sde[ii]);
 	// partial observations
 	if(nObsComp[ii] == 0) {
-	  for(jj = 0; jj < nDims; jj++) mvX[ii]->z[jj] = norm_rand();
+	  for(jj = 0; jj < nDims; jj++) mvX[ii]->z[jj] = NORM_RAND();
 	}
 	else {
 	  zmvn(mvX[ii]->z, &currX[ii*nDims], mvX[ii]->mean,
 	       mvX[ii]->sd, nDims, nObsComp[ii]);
 	  for(jj = nObsComp[ii]; jj < nDims; jj++) {
-	    mvX[ii]->z[jj] = norm_rand();
+	    mvX[ii]->z[jj] = NORM_RAND();
 	  }
 	}
 	// proposals
@@ -87,14 +87,14 @@ void sdeMCMC::missGibbsUpdate(double *jumpSd, int *gibbsAccept, int *paramAccept
     // partial observations
     if(nObsComp[ii] == 0) {
       for(jj = 0; jj < nDims; jj++) {
-	mvX[ii]->z[jj] = norm_rand();
+	mvX[ii]->z[jj] = NORM_RAND();
       }
     }
     else {
       zmvn(mvX[ii]->z, &currX[ii*nDims], mvX[ii]->mean,
 	   mvX[ii]->sd, nDims, nObsComp[ii]);
       for(jj = nObsComp[ii]; jj < nDims; jj++) {
-	mvX[ii]->z[jj] = norm_rand();
+	mvX[ii]->z[jj] = NORM_RAND();
       }
     }
     // proposals
@@ -123,7 +123,7 @@ void sdeMCMC::missGibbsUpdate(double *jumpSd, int *gibbsAccept, int *paramAccept
     // random walk metropolis
     for(jj = 0; jj < nMiss0; jj++) {
       // proposal
-      propX[nObsComp[0]+jj] = currX[nObsComp[0]+jj] + jumpSd[nParams+jj] * norm_rand();
+      propX[nObsComp[0]+jj] = currX[nObsComp[0]+jj] + jumpSd[nParams+jj] * NORM_RAND();
       if(sdeModel::isValidData(&propX[ii*nDims])) {
 	// acceptance rate.
 	// target 1

--- a/inst/cppTemplates/mvnUtils.cpp
+++ b/inst/cppTemplates/mvnUtils.cpp
@@ -121,7 +121,7 @@ double lmvn(double *x, double *z, double *mean, double *cholSd, int n) {
     tmpSum = 0.0;
     for(jj = 0; jj < ii; jj++) tmpSum += cholSd[colI + jj] * z[jj];
     val = (resi - tmpSum) / cholSd[colI + ii];
-    tmpSum3 += log(cholSd[colI + ii]);
+    tmpSum3 += LOG(cholSd[colI + ii]);
     z[ii] = val;
     tmpSum2 += (val * val);
     colI += n;
@@ -176,7 +176,7 @@ double lgcop(double *x, double *qNorm, int *nBreaks, double *range,
   }
   tmpSum *= 0.5;
   for(ii = 0; ii < n; ii++) {
-    tmpSum += log(RhoCholSd[n*ii + ii]);
+    tmpSum += LOG(RhoCholSd[n*ii + ii]);
   }
   lp -= tmpSum;
   return(lp);

--- a/inst/cppTemplates/paramVanillaUpdate.cpp
+++ b/inst/cppTemplates/paramVanillaUpdate.cpp
@@ -18,7 +18,7 @@ void sdeMCMC::paramVanillaUpdate(double *jumpSd, int *paramAccept) {
   for(ii = 0; ii < nParams; ii++) {
     if(!fixedTheta[ii]) {
     // proposal
-    propTheta[ii] = currTheta[ii] + jumpSd[ii] * norm_rand();
+    propTheta[ii] = currTheta[ii] + jumpSd[ii] * NORM_RAND();
     // only calculate acceptance if valid
     if(sdeModel::isValidParams(propTheta)) {
       // likelihood

--- a/msdeTest.Rproj
+++ b/msdeTest.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/src/EulerSim.cpp
+++ b/src/EulerSim.cpp
@@ -49,13 +49,13 @@ List sdeEulerSim(int nDataOut,
 	mvEuler(mvX[ii]->mean, mvX[ii]->sd, X, delta, sqrtDelta,
 		&params[ii*nParams], &sde[ii]);
 	for(kk = 0; kk < nDims; kk++) {
-	  mvX[ii]->z[kk] = norm_rand();
+	  mvX[ii]->z[kk] = NORM_RAND();
 	}
 	xmvn(tmpX, mvX[ii]->z, mvX[ii]->mean, mvX[ii]->sd, nDims);
 	// validate draw
 	while(!sdeModel::isValidData(tmpX) && bad < MAXBAD) {
 	  for(kk = 0; kk < nDims; kk++) {
-	    mvX[ii]->z[kk] = norm_rand();
+	    mvX[ii]->z[kk] = NORM_RAND();
 	  }
 	  xmvn(tmpX, mvX[ii]->z, mvX[ii]->mean, mvX[ii]->sd, nDims);
 	  bad++;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -23,6 +23,27 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// plnorm_rand
+double plnorm_rand();
+RcppExport SEXP msdeTest_plnorm_rand() {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    __result = Rcpp::wrap(plnorm_rand());
+    return __result;
+END_RCPP
+}
+// rplnorm
+NumericVector rplnorm(int n);
+RcppExport SEXP msdeTest_rplnorm(SEXP nSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< int >::type n(nSEXP);
+    __result = Rcpp::wrap(rplnorm(n));
+    return __result;
+END_RCPP
+}
 // sdeDrift
 NumericVector sdeDrift(NumericVector xIn, NumericVector thetaIn, int nReps);
 RcppExport SEXP msdeTest_sdeDrift(SEXP xInSEXP, SEXP thetaInSEXP, SEXP nRepsSEXP) {

--- a/src/libm_log.cpp
+++ b/src/libm_log.cpp
@@ -1,0 +1,253 @@
+/*
+
+This is an implementation of the fast log function taken from the openlibm
+https://github.com/JuliaLang/openlibm.
+
+This version is significantly faster than the one available with MinGW.
+
+This file was created by modifying the original e_log.c file to add in values
+from the associated headers and to remove items that were not relevant when
+compiled with GCC/Clang.
+
+*/
+
+
+/* @(#)e_log.c 1.3 95/01/18 */
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunSoft, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice 
+ * is preserved.
+ * ====================================================
+ */
+
+//#include "cdefs-compat.h"
+//__FBSDID("$FreeBSD: src/lib/msun/src/e_log.c,v 1.15 2008/03/29 16:37:59 das Exp $");
+
+/* __ieee754_log(x)
+ * Return the logrithm of x
+ *
+ * Method :                  
+ *   1. Argument Reduction: find k and f such that 
+ *			x = 2^k * (1+f), 
+ *	   where  sqrt(2)/2 < 1+f < sqrt(2) .
+ *
+ *   2. Approximation of log(1+f).
+ *	Let s = f/(2+f) ; based on log(1+f) = log(1+s) - log(1-s)
+ *		 = 2s + 2/3 s**3 + 2/5 s**5 + .....,
+ *	     	 = 2s + s*R
+ *      We use a special Reme algorithm on [0,0.1716] to generate 
+ * 	a polynomial of degree 14 to approximate R The maximum error 
+ *	of this polynomial approximation is bounded by 2**-58.45. In
+ *	other words,
+ *		        2      4      6      8      10      12      14
+ *	    R(z) ~ Lg1*s +Lg2*s +Lg3*s +Lg4*s +Lg5*s  +Lg6*s  +Lg7*s
+ *  	(the values of Lg1 to Lg7 are listed in the program)
+ *	and
+ *	    |      2          14          |     -58.45
+ *	    | Lg1*s +...+Lg7*s    -  R(z) | <= 2 
+ *	    |                             |
+ *	Note that 2s = f - s*f = f - hfsq + s*hfsq, where hfsq = f*f/2.
+ *	In order to guarantee error in log below 1ulp, we compute log
+ *	by
+ *		log(1+f) = f - s*(f - R)	(if f is not too large)
+ *		log(1+f) = f - (hfsq - s*(hfsq+R)).	(better accuracy)
+ *	
+ *	3. Finally,  log(x) = k*ln2 + log(1+f).  
+ *			    = k*ln2_hi+(f-(hfsq-(s*(hfsq+R)+k*ln2_lo)))
+ *	   Here ln2 is split into two floating point number: 
+ *			ln2_hi + ln2_lo,
+ *	   where n*ln2_hi is always exact for |n| < 2000.
+ *
+ * Special cases:
+ *	log(x) is NaN with signal if x < 0 (including -INF) ; 
+ *	log(+INF) is +INF; log(0) is -INF with signal;
+ *	log(NaN) is that NaN with no signal.
+ *
+ * Accuracy:
+ *	according to an error analysis, the error is always less than
+ *	1 ulp (unit in the last place).
+ *
+ * Constants:
+ * The hexadecimal values are the intended ones for the following 
+ * constants. The decimal values may be used, provided that the 
+ * compiler will convert from decimal to binary accurately enough 
+ * to produce the hexadecimal values shown.
+ */
+
+//#include <openlibm_math.h>
+// #include "math_private.h"
+
+// DEFINE MACROS AND HEADERS NEEDED FOR COMPILATION
+
+//////////// From types-compat.h  ////////////////
+#include <stdint.h>
+#include <limits.h>
+
+typedef uint8_t               u_int8_t;
+typedef uint16_t              u_int16_t;
+typedef uint32_t              u_int32_t;
+typedef uint64_t              u_int64_t;
+
+////////////////// FROM math_private.h   /////////////////////
+#ifndef _MSC_VER
+/* These definitions should be provided directly by GCC and Clang.  */
+#if !(defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__))
+#error The compiler needs to define the byte order
+#endif
+#define __FLOAT_WORD_ORDER__     __BYTE_ORDER__
+
+
+/*
+ * A union which permits us to convert between a double and two 32 bit
+ * ints.
+ */
+#endif 
+
+
+#if __FLOAT_WORD_ORDER__ == __ORDER_BIG_ENDIAN__
+
+typedef union
+{
+  double value;
+  struct
+  {
+    u_int32_t msw;
+    u_int32_t lsw;
+  } parts;
+  struct
+  {
+    u_int64_t w;
+  } xparts;
+} ieee_double_shape_type;
+
+#endif
+
+#if __FLOAT_WORD_ORDER__ == __ORDER_LITTLE_ENDIAN__
+
+typedef union
+{
+  double value;
+  struct
+  {
+    u_int32_t lsw;
+    u_int32_t msw;
+  } parts;
+  struct
+  {
+    u_int64_t w;
+  } xparts;
+} ieee_double_shape_type;
+
+#endif
+
+#define EXTRACT_WORDS(ix0,ix1,d)				\
+do {								\
+  ieee_double_shape_type ew_u;					\
+  ew_u.value = (d);						\
+  (ix0) = ew_u.parts.msw;					\
+  (ix1) = ew_u.parts.lsw;					\
+} while (0)
+
+/* Get the more significant 32 bit int from a double.  */
+
+#define GET_HIGH_WORD(i,d)					\
+do {								\
+  ieee_double_shape_type gh_u;					\
+  gh_u.value = (d);						\
+  (i) = gh_u.parts.msw;						\
+} while (0)
+
+/* Set the more significant 32 bits of a double from an int.  */
+
+#define SET_HIGH_WORD(d,v)					\
+do {								\
+  ieee_double_shape_type sh_u;					\
+  sh_u.value = (d);						\
+  sh_u.parts.msw = (v);						\
+  (d) = sh_u.value;						\
+} while (0)
+
+
+//// NOW THE MAIN LOG FUNCTION (FROM e_log.c)   //////////
+
+// This attibute was previously specified to enable this thing to be exported in all case, avoiding it for now
+// __attribute__ ((visibility("default"))) 
+double libmlog(double x)
+{
+	// These were moved from outside of the global namespace, were previously static const
+	const double
+    ln2_hi  =  6.93147180369123816490e-01,	/* 3fe62e42 fee00000 */
+    ln2_lo  =  1.90821492927058770002e-10,	/* 3dea39ef 35793c76 */
+    two54   =  1.80143985094819840000e+16,  /* 43500000 00000000 */
+    Lg1 = 6.666666666666735130e-01,  /* 3FE55555 55555593 */
+    Lg2 = 3.999999999940941908e-01,  /* 3FD99999 9997FA04 */
+    Lg3 = 2.857142874366239149e-01,  /* 3FD24924 94229359 */
+    Lg4 = 2.222219843214978396e-01,  /* 3FCC71C5 1D8E78AF */
+    Lg5 = 1.818357216161805012e-01,  /* 3FC74664 96CB03DE */
+    Lg6 = 1.531383769920937332e-01,  /* 3FC39A09 D078C69F */
+    Lg7 = 1.479819860511658591e-01;  /* 3FC2F112 DF3E5244 */    
+    
+    const double zero   =  0.0;
+
+	double hfsq,f,s,z,R,w,t1,t2,dk;
+	int32_t k,hx,i,j;
+	u_int32_t lx;
+
+	EXTRACT_WORDS(hx,lx,x);
+
+	k=0;
+	if (hx < 0x00100000) {			/* x < 2**-1022  */
+	    if (((hx&0x7fffffff)|lx)==0) 
+		return -two54/zero;		/* log(+-0)=-inf */
+	    if (hx<0) return (x-x)/zero;	/* log(-#) = NaN */
+	    k -= 54; x *= two54; /* subnormal number, scale up x */
+	    GET_HIGH_WORD(hx,x);
+	} 
+	if (hx >= 0x7ff00000) return x+x;
+	k += (hx>>20)-1023;
+	hx &= 0x000fffff;
+	i = (hx+0x95f64)&0x100000;
+	SET_HIGH_WORD(x,hx|(i^0x3ff00000));	/* normalize x or x/2 */
+	k += (i>>20);
+	f = x-1.0;
+	if((0x000fffff&(2+hx))<3) {	/* -2**-20 <= f < 2**-20 */
+	    if(f==zero) {
+		if(k==0) {
+		    return zero;
+		} else {
+		    dk=(double)k;
+		    return dk*ln2_hi+dk*ln2_lo;
+		}
+	    }
+	    R = f*f*(0.5-0.33333333333333333*f);
+	    if(k==0) return f-R; else {dk=(double)k;
+	    	     return dk*ln2_hi-((R-dk*ln2_lo)-f);}
+	}
+ 	s = f/(2.0+f); 
+	dk = (double)k;
+	z = s*s;
+	i = hx-0x6147a;
+	w = z*z;
+	j = 0x6b851-hx;
+	t1= w*(Lg2+w*(Lg4+w*Lg6)); 
+	t2= z*(Lg1+w*(Lg3+w*(Lg5+w*Lg7))); 
+	i |= j;
+	R = t2+t1;
+	if(i>0) {
+	    hfsq=0.5*f*f;
+	    if(k==0) return f-(hfsq-s*(hfsq+R)); else
+		     return dk*ln2_hi-((hfsq-(s*(hfsq+R)+dk*ln2_lo))-f);
+	} else {
+	    if(k==0) return f-s*(f-R); else
+		     return dk*ln2_hi-((s*(f-R)-dk*ln2_lo)-f);
+	}
+}
+
+// Now to undef to avoid polluting the namespace
+#undef EXTRACT_WORDS
+#undef GET_HIGH_WORD
+#undef SET_HIGH_WORD

--- a/src/libm_log.h
+++ b/src/libm_log.h
@@ -1,0 +1,1 @@
+double libmlog(double x);

--- a/src/logSwapper.h
+++ b/src/logSwapper.h
@@ -1,8 +1,8 @@
 /* Source file to swap out and test different forms of log and norm_rand.
    changing the definition of LOG can point it to a different implementation.
  */
-#ifndef swappableDefinitions_h
-#define swappableDefinitions_h 1
+#ifndef logSwapper_h
+#define logSwapper_h 1
 
 #ifndef __APPLE__
   // This function is faster on windows

--- a/src/missGibbsUpdate.cpp
+++ b/src/missGibbsUpdate.cpp
@@ -27,13 +27,13 @@ void sdeMCMC::missGibbsUpdate(double *jumpSd, int *gibbsAccept, int *paramAccept
 		 &currX[(ii+1)*nDims], B[ii], sqrtB[ii], currTheta, &sde[ii]);
 	// partial observations
 	if(nObsComp[ii] == 0) {
-	  for(jj = 0; jj < nDims; jj++) mvX[ii]->z[jj] = norm_rand();
+	  for(jj = 0; jj < nDims; jj++) mvX[ii]->z[jj] = NORM_RAND();
 	}
 	else {
 	  zmvn(mvX[ii]->z, &currX[ii*nDims], mvX[ii]->mean,
 	       mvX[ii]->sd, nDims, nObsComp[ii]);
 	  for(jj = nObsComp[ii]; jj < nDims; jj++) {
-	    mvX[ii]->z[jj] = norm_rand();
+	    mvX[ii]->z[jj] = NORM_RAND();
 	  }
 	}
 	// proposals
@@ -87,14 +87,14 @@ void sdeMCMC::missGibbsUpdate(double *jumpSd, int *gibbsAccept, int *paramAccept
     // partial observations
     if(nObsComp[ii] == 0) {
       for(jj = 0; jj < nDims; jj++) {
-	mvX[ii]->z[jj] = norm_rand();
+	mvX[ii]->z[jj] = NORM_RAND();
       }
     }
     else {
       zmvn(mvX[ii]->z, &currX[ii*nDims], mvX[ii]->mean,
 	   mvX[ii]->sd, nDims, nObsComp[ii]);
       for(jj = nObsComp[ii]; jj < nDims; jj++) {
-	mvX[ii]->z[jj] = norm_rand();
+	mvX[ii]->z[jj] = NORM_RAND();
       }
     }
     // proposals

--- a/src/mvnUtils.cpp
+++ b/src/mvnUtils.cpp
@@ -121,7 +121,7 @@ double lmvn(double *x, double *z, double *mean, double *cholSd, int n) {
     tmpSum = 0.0;
     for(jj = 0; jj < ii; jj++) tmpSum += cholSd[colI + jj] * z[jj];
     val = (resi - tmpSum) / cholSd[colI + ii];
-    tmpSum3 += log(cholSd[colI + ii]);
+    tmpSum3 += LOG(cholSd[colI + ii]);
     z[ii] = val;
     tmpSum2 += (val * val);
     colI += n;
@@ -176,7 +176,7 @@ double lgcop(double *x, double *qNorm, int *nBreaks, double *range,
   }
   tmpSum *= 0.5;
   for(ii = 0; ii < n; ii++) {
-    tmpSum += log(RhoCholSd[n*ii + ii]);
+    tmpSum += LOG(RhoCholSd[n*ii + ii]);
   }
   lp -= tmpSum;
   return(lp);

--- a/src/mvnUtils.h
+++ b/src/mvnUtils.h
@@ -5,7 +5,8 @@
 
 
 #include <Rcpp.h>
-#include "swappableDefinitions.h"
+#include "logSwapper.h"
+#include "normRandSwapper.h"
 using namespace Rcpp;
 
 

--- a/src/mvnUtils.h
+++ b/src/mvnUtils.h
@@ -3,8 +3,11 @@
 #ifndef mvnUtils_h
 #define mvnUtils_h 1
 
+
 #include <Rcpp.h>
+#include "swappableDefinitions.h"
 using namespace Rcpp;
+
 
 // a few utility functions for multivariate normals
 

--- a/src/normRandSwapper.h
+++ b/src/normRandSwapper.h
@@ -1,0 +1,12 @@
+/* Source file to swap out and test different forms of log and norm_rand.
+ changing the definition of LOG can point it to a different implementation.
+ */
+#ifndef normRandSwapper_h
+#define normRandSwapper_h 1
+
+#include "polarNormRand.h"
+#define NORM_RAND plnorm_rand
+
+
+
+#endif

--- a/src/paramVanillaUpdate.cpp
+++ b/src/paramVanillaUpdate.cpp
@@ -18,7 +18,7 @@ void sdeMCMC::paramVanillaUpdate(double *jumpSd, int *paramAccept) {
   for(ii = 0; ii < nParams; ii++) {
     if(!fixedTheta[ii]) {
     // proposal
-    propTheta[ii] = currTheta[ii] + jumpSd[ii] * norm_rand();
+    propTheta[ii] = currTheta[ii] + jumpSd[ii] * NORM_RAND();
     // only calculate acceptance if valid
     if(sdeModel::isValidParams(propTheta)) {
       // likelihood

--- a/src/polarNormRand.cpp
+++ b/src/polarNormRand.cpp
@@ -1,0 +1,70 @@
+#include "polarNormRand.h"
+
+using namespace Rcpp;
+
+double norm_keep = 0.0;
+
+// Polar Form of Box-Muller Normal RNG See explanation at:
+// http://www.design.caltech.edu/erik/Misc/Gaussian.html
+// And it’s also explained on pages 494-496 of the A First Course in 
+// Probability by Sheldon Ross, 7th Edition.
+//[[Rcpp::export]]
+double plnorm_rand() {
+	double x1, x2, w, s;
+	if(norm_keep != 0.0) { /* An exact test is intentional */
+       s = norm_keep;
+       norm_keep = 0.0;
+       return s;
+    } else {
+		do {
+	        x1 = 2.0 * unif_rand() - 1.0;
+	        x2 = 2.0 * unif_rand() - 1.0;
+	        w = x1 * x1 + x2 * x2;
+		} while ( w >= 1.0 );
+		w = sqrt( (-2.0 * LOG( w ) ) / w );
+		norm_keep = x2 * w;
+		return x1 * w;
+	}
+}
+
+//' Simulate random standard normals using the polar form of the Box-Muller 
+//' transformation.  Box-Muller is much faster than the Inversion method,
+//' and this method is a faster version of that provided that the unif_rand
+//' function is fast (otherwise performance is near BM).  Sample timings below.
+//'
+//'  > n = 5000000
+//'  > message("R standard")
+//'  R standard
+//'  > RNGkind(kind="Mersenne-Twister")
+//'  > RNGkind(normal.kind = "Inversion")
+//'  > system.time(rnorm(n))
+//'     user  system elapsed 
+//'    0.444   0.004   0.450 
+//'  > message("BM + Twister")
+//'  BM + Twister
+//'  > RNGkind(normal.kind = "Box-Muller")
+//'  > system.time(rnorm(n))
+//'     user  system elapsed 
+//'    0.278   0.003   0.282 
+//'  > message("Polar + Twister")
+//'  Polar + Twister
+//'  > system.time(msdeTest:::rplnorm(n))
+//'     user  system elapsed 
+//'    0.270   0.003   0.274 
+//'  > message("Polar + Carry")
+//'  Polar + Carry
+//'  > RNGkind(kind="Marsaglia-Multicarry")
+//'  > system.time(msdeTest:::rplnorm(n))
+//'     user  system elapsed 
+//'    0.234   0.003   0.238 
+//' @param n Number of draws to take.
+//' @return The size of the multinomial distributions
+//' @export
+// [[Rcpp::export]]
+NumericVector rplnorm(int n) {
+  NumericVector vals(n);
+  for(int i = 0; i < n; i++) {
+    vals[i] = plnorm_rand();
+  }
+  return vals;
+}

--- a/src/polarNormRand.h
+++ b/src/polarNormRand.h
@@ -1,0 +1,4 @@
+#include <Rcpp.h>
+#include "logSwapper.h"
+
+double plnorm_rand();

--- a/src/swappableDefinitions.h
+++ b/src/swappableDefinitions.h
@@ -4,9 +4,14 @@
 #ifndef swappableDefinitions_h
 #define swappableDefinitions_h 1
 
-#include "libm_log.h"
-#define LOG libmlog
-
+#ifndef __APPLE__
+  // This function is faster on windows
+  #include "libm_log.h"
+  #define LOG libmlog
+#else
+  // The libm implementation of log on Mac OSX is plenty fast.
+  #define LOG log 
+#endif
 
 
 

--- a/src/swappableDefinitions.h
+++ b/src/swappableDefinitions.h
@@ -1,0 +1,13 @@
+/* Source file to swap out and test different forms of log and norm_rand.
+   changing the definition of LOG can point it to a different implementation.
+ */
+#ifndef swappableDefinitions_h
+#define swappableDefinitions_h 1
+
+#include "libm_log.h"
+#define LOG libmlog
+
+
+
+
+#endif


### PR DESCRIPTION
Early profiling showed that generating normal random numbers was slow, and part of this was due to how long the log/cos/sin functions took.  Digging deeper showed the MinGW was using a really old version of the log function (https://sourceforge.net/p/mingw/mingw-org-wsl/ci/21762bb4a1bd0c88c38eead03f59e8d994349e83/tree/src/libcrt/math/logl.S) that was far slower than the ones used by the native windows compiler or by the mac libraries.

To address this, I took the log function from the Julia openlibm library (https://github.com/JuliaLang/openlibm/blob/960fdbf8bd01cc2524c1a9e1a94110d1a4f1964a/src/e_log.c) and ported it over here.  This function when compiled with MinGW shaves off about ~35% of the time, but is still about twice as slow as the windows compiler version and about 35% slower than Mac OSX's libm version.

It appears this function is incredibly accurate though (always < 1 unit in last place), and in the future it might also be useful to try out some less-accurate/faster versions.